### PR TITLE
Use explicit alignment for thumbnail background

### DIFF
--- a/oscc.lua
+++ b/oscc.lua
@@ -831,6 +831,7 @@ function render_elements(master_ass)
 
                             elem_ass:new_event()
                             elem_ass:pos(thumb_x * r_w, thumb_y * r_h)
+                            elem_ass:an(7)
                             elem_ass:append(osc_styles.box)
                             elem_ass:append("{\\1a&H20&}")
                             elem_ass:draw_start()


### PR DESCRIPTION
Some clients do not default ASS alignment to 7, which is what we expect.

This was an issue on 3rd party clients like Syncplay and MPV-EASY. https://github.com/po5/thumbfast/issues/100, https://github.com/po5/thumbfast/issues/81